### PR TITLE
Fix import of InstanceAdd.react.js

### DIFF
--- a/js/components/InstanceSelect.react.js
+++ b/js/components/InstanceSelect.react.js
@@ -6,7 +6,7 @@ import ErrorActions from '../actions/ErrorActions';
 import InstanceActions from '../actions/InstanceActions';
 import InstanceStore from '../stores/InstanceStore';
 import ServerStore from '../stores/ServerStore';
-import InstanceAdd from './InstanceAdd.React.js';
+import InstanceAdd from './InstanceAdd.react.js';
 import AltContainer from 'alt-container';
 import config from '../utils/config';
 import ServerActions from '../actions/ServerActions';


### PR DESCRIPTION
Was previously referencing `InstanceAdd.React.js` which failed on any case-sensitive filesystem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/janelia-flyem/dvid-console/46)
<!-- Reviewable:end -->
